### PR TITLE
chore: add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Error logs
 yarn-error.log
 lerna-debug.log
+/node_modules/
 
 # Ember addon readme
 packages/ember-cli-stencil/README.md


### PR DESCRIPTION
Not much value added but I've found myself annoyed by the presence of `node_modules`
at the root of the project in my `git status` :)