### PR TITLE
fix: enable Babel parallelization in downstream builds

### DIFF
--- a/packages/ember-cli-stencil/ember-cli-build.js
+++ b/packages/ember-cli-stencil/ember-cli-build.js
@@ -3,7 +3,12 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {});
+  let app = new EmberAddon(defaults, {
+    'ember-cli-babel': {
+      // Make sure this addon doesn't break Babel parallelization in downstream builds
+      throwUnlessParallelizable: true
+    }
+  });
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/packages/ember-cli-stencil/index.js
+++ b/packages/ember-cli-stencil/index.js
@@ -44,7 +44,7 @@ module.exports = {
     const opts = this.allOptions();
     opts.babel = opts.babel || {};
     opts.babel.plugins = opts.babel.plugins || [];
-    opts.babel.plugins.push(require('ember-auto-import/babel-plugin'));
+    opts.babel.plugins.push(require.resolve('ember-auto-import/babel-plugin'));
 
     let parentDepsPackages;
     if (this.addonDiscovery) {


### PR DESCRIPTION
https://github.com/ef4/ember-auto-import/pull/199

https://github.com/babel/ember-cli-babel#parallel-builds